### PR TITLE
膨張係数の入力が無い部材は、無効としていた

### DIFF
--- a/Convert_Manager/FrameWebForJS/element.cs
+++ b/Convert_Manager/FrameWebForJS/element.cs
@@ -63,7 +63,7 @@ namespace Convert_Manager.FrameWebForJS
                         e.Iz = Iz[j] * n;
                     }
                     // 有効判定
-                    if (e.E != 0 && e.Xp != 0 && e.A != 0 && e.Iz != 0)
+                    if (e.E != 0 && e.A != 0 && e.Iz != 0)
                     {
                         eee.Add(No, e);
                     }


### PR DESCRIPTION
膨張係数の入力が無くても断面積と断面二次モーメントの入力があれば有効な部材とした